### PR TITLE
Add support for patterns in UrlKeyResolver

### DIFF
--- a/dnstapir/key_resolver.py
+++ b/dnstapir/key_resolver.py
@@ -1,3 +1,4 @@
+import logging
 from abc import abstractmethod
 from pathlib import Path
 from urllib.parse import urljoin
@@ -31,6 +32,10 @@ def key_resolver_from_client_database(client_database: str, key_cache: KeyCache 
 
 
 class KeyResolver:
+
+    def __init__(self):
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+
     @abstractmethod
     def resolve_public_key(self, key_id: str) -> PublicKey:
         pass
@@ -38,6 +43,7 @@ class KeyResolver:
 
 class CacheKeyResolver(KeyResolver):
     def __init__(self, key_cache: KeyCache | None):
+        super().__init__()
         self.key_cache = key_cache
 
     @abstractmethod
@@ -65,6 +71,7 @@ class FileKeyResolver(CacheKeyResolver):
     def get_public_key_pem(self, key_id: str) -> bytes:
         with tracer.start_as_current_span("get_public_key_pem_from_file"):
             filename = Path(self.client_database_directory) / f"{key_id}.pem"
+            self.logger.debug("Fetching public key for %s from %s", key_id, filename)
             try:
                 with open(filename, "rb") as fp:
                     return fp.read()
@@ -77,10 +84,15 @@ class UrlKeyResolver(CacheKeyResolver):
         super().__init__(key_cache=key_cache)
         self.client_database_base_url = client_database_base_url
         self._httpx_client: httpx.Client | None = None
+        self.key_id_pattern = "%s"
 
     def get_public_key_pem(self, key_id: str) -> bytes:
         with tracer.start_as_current_span("get_public_key_pem_from_url"):
-            public_key_url = urljoin(self.client_database_base_url, f"{key_id}.pem")
+            if self.key_id_pattern in self.client_database_base_url:
+                public_key_url = self.client_database_base_url.replace(self.key_id_pattern, key_id)
+            else:
+                public_key_url = urljoin(self.client_database_base_url, f"{key_id}.pem")
+            self.logger.debug("Fetching public key for %s from %s", key_id, public_key_url)
             try:
                 response = self.httpx_client.get(public_key_url)
                 response.raise_for_status()
@@ -91,7 +103,7 @@ class UrlKeyResolver(CacheKeyResolver):
     @property
     def httpx_client(self) -> httpx.Client:
         if self._httpx_client is None:
-            self._httpx_client = httpx.Client()
+            self._httpx_client = httpx.Client(headers={"Accept": "application/x-pem-file"})
         return self._httpx_client
 
     def __enter__(self):

--- a/dnstapir/key_resolver.py
+++ b/dnstapir/key_resolver.py
@@ -32,7 +32,6 @@ def key_resolver_from_client_database(client_database: str, key_cache: KeyCache 
 
 
 class KeyResolver:
-
     def __init__(self):
         self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dnstapir"
-version = "1.1.0"
+version = "1.2.0"
 description = "DNS TAPIR Python Library"
 authors = ["Jakob Schlyter <jakob@kirei.se>"]
 readme = "README.md"

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -43,6 +43,9 @@ def test_url_key_resolver(httpx_mock: HTTPXMock):
     res = resolver.resolve_public_key(key_id)
     assert res == public_key
 
+    request = httpx_mock.get_request()
+    assert request.headers["Accept"] == "application/x-pem-file"
+
     with pytest.raises(KeyError):
         _ = resolver.resolve_public_key("unknown")
 
@@ -60,6 +63,9 @@ def test_url_key_resolver_pattern(httpx_mock: HTTPXMock):
     resolver = UrlKeyResolver(client_database_base_url="https://nodeman/api/v1/node/%s/public_key")
     res = resolver.resolve_public_key(key_id)
     assert res == public_key
+
+    request = httpx_mock.get_request()
+    assert request.headers["Accept"] == "application/x-pem-file"
 
     with pytest.raises(KeyError):
         _ = resolver.resolve_public_key("unknown")

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -25,6 +25,9 @@ def test_file_key_resolver(httpx_mock: HTTPXMock):
         res = resolver.resolve_public_key(key_id)
         assert res == public_key
 
+        with pytest.raises(ValueError):
+            _ = resolver.resolve_public_key("🔐")
+
         with pytest.raises(KeyError):
             _ = resolver.resolve_public_key("unknown")
 

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -46,6 +46,9 @@ def test_url_key_resolver(httpx_mock: HTTPXMock):
     request = httpx_mock.get_request()
     assert request.headers["Accept"] == "application/x-pem-file"
 
+    with pytest.raises(ValueError):
+        _ = resolver.resolve_public_key("🔐")
+
     with pytest.raises(KeyError):
         _ = resolver.resolve_public_key("unknown")
 

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -1,9 +1,32 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from pytest_httpx import HTTPXMock
 
-from dnstapir.key_resolver import UrlKeyResolver
+from dnstapir.key_resolver import FileKeyResolver, UrlKeyResolver
+
+
+def test_file_key_resolver(httpx_mock: HTTPXMock):
+    key_id = "xyzzy"
+    public_key = ed25519.Ed25519PrivateKey.generate().public_key()
+    public_key_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+
+    with TemporaryDirectory(prefix="dnstapir") as directory:
+        pem_filename = Path(directory) / f"{key_id}.pem"
+        with open(pem_filename, "wb") as fp:
+            fp.write(public_key_pem)
+
+        resolver = FileKeyResolver(client_database_directory=directory)
+        res = resolver.resolve_public_key(key_id)
+        assert res == public_key
+
+        with pytest.raises(KeyError):
+            _ = resolver.resolve_public_key("unknown")
 
 
 def test_url_key_resolver(httpx_mock: HTTPXMock):
@@ -21,7 +44,7 @@ def test_url_key_resolver(httpx_mock: HTTPXMock):
     assert res == public_key
 
     with pytest.raises(KeyError):
-        res = resolver.resolve_public_key("unknown")
+        _ = resolver.resolve_public_key("unknown")
 
 
 def test_url_key_resolver_pattern(httpx_mock: HTTPXMock):
@@ -39,7 +62,7 @@ def test_url_key_resolver_pattern(httpx_mock: HTTPXMock):
     assert res == public_key
 
     with pytest.raises(KeyError):
-        res = resolver.resolve_public_key("unknown")
+        _ = resolver.resolve_public_key("unknown")
 
 
 def test_url_key_resolver_contextlib(httpx_mock: HTTPXMock):
@@ -50,7 +73,11 @@ def test_url_key_resolver_contextlib(httpx_mock: HTTPXMock):
     )
 
     httpx_mock.add_response(url=f"https://keys/{key_id}.pem", content=public_key_pem)
+    httpx_mock.add_response(url="https://keys/unknown.pem", status_code=404)
 
     with UrlKeyResolver(client_database_base_url="https://keys") as resolver:
         res = resolver.resolve_public_key(key_id)
         assert res == public_key
+
+    with pytest.raises(KeyError):
+        _ = resolver.resolve_public_key("unknown")

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -1,3 +1,4 @@
+import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from pytest_httpx import HTTPXMock
@@ -13,10 +14,32 @@ def test_url_key_resolver(httpx_mock: HTTPXMock):
     )
 
     httpx_mock.add_response(url=f"https://keys/{key_id}.pem", content=public_key_pem)
+    httpx_mock.add_response(url="https://keys/unknown.pem", status_code=404)
 
     resolver = UrlKeyResolver(client_database_base_url="https://keys")
     res = resolver.resolve_public_key(key_id)
     assert res == public_key
+
+    with pytest.raises(KeyError):
+        res = resolver.resolve_public_key("unknown")
+
+
+def test_url_key_resolver_pattern(httpx_mock: HTTPXMock):
+    key_id = "xyzzy"
+    public_key = ed25519.Ed25519PrivateKey.generate().public_key()
+    public_key_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM, format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+
+    httpx_mock.add_response(url=f"https://nodeman/api/v1/node/{key_id}/public_key", content=public_key_pem)
+    httpx_mock.add_response(url="https://nodeman/api/v1/node/unknown/public_key", status_code=404)
+
+    resolver = UrlKeyResolver(client_database_base_url="https://nodeman/api/v1/node/%s/public_key")
+    res = resolver.resolve_public_key(key_id)
+    assert res == public_key
+
+    with pytest.raises(KeyError):
+        res = resolver.resolve_public_key("unknown")
 
 
 def test_url_key_resolver_contextlib(httpx_mock: HTTPXMock):


### PR DESCRIPTION
To be able to support key lookups with https://github.com/dnstapir/nodeman, we need to be able to set the `client_database` to something like `https://nodeman/api/v1/node/%s/public_key`. We also need to set the header `Accept: application/x-pem-file` to indicate we want the public key in PEM format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced logging for key resolution processes.
	- Improved flexibility in URL handling for public key retrieval.
	- Default headers added to the HTTP client for PEM file format acceptance.
	- New method for key ID validation introduced.

- **Bug Fixes**
	- Added error handling for unknown key IDs in both `FileKeyResolver` and `UrlKeyResolver`.

- **Tests**
	- Introduced new test functions for `FileKeyResolver` and `UrlKeyResolver`, improving test coverage and error handling validation.

- **Chores**
	- Updated version of the `dnstapir` library in `pyproject.toml`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->