### PR TITLE
Update key id pattern

### DIFF
--- a/dnstapir/key_resolver.py
+++ b/dnstapir/key_resolver.py
@@ -90,7 +90,7 @@ class UrlKeyResolver(CacheKeyResolver):
         super().__init__(key_cache=key_cache)
         self.client_database_base_url = client_database_base_url
         self._httpx_client: httpx.Client | None = None
-        self.key_id_pattern = "%s"
+        self.key_id_pattern = "{key_id}"
 
     def get_public_key_pem(self, key_id: str) -> bytes:
         with tracer.start_as_current_span("get_public_key_pem_from_url"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dnstapir"
-version = "1.2.0"
+version = "1.2.1"
 description = "DNS TAPIR Python Library"
 authors = ["Jakob Schlyter <jakob@kirei.se>"]
 readme = "README.md"

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -66,7 +66,7 @@ def test_url_key_resolver_pattern(httpx_mock: HTTPXMock):
     httpx_mock.add_response(url=f"https://nodeman/api/v1/node/{key_id}/public_key", content=public_key_pem)
     httpx_mock.add_response(url="https://nodeman/api/v1/node/unknown/public_key", status_code=404)
 
-    resolver = UrlKeyResolver(client_database_base_url="https://nodeman/api/v1/node/%s/public_key")
+    resolver = UrlKeyResolver(client_database_base_url="https://nodeman/api/v1/node/{key_id}/public_key")
     res = resolver.resolve_public_key(key_id)
     assert res == public_key
 

--- a/tests/test_key_resolver.py
+++ b/tests/test_key_resolver.py
@@ -77,6 +77,14 @@ def test_url_key_resolver_pattern(httpx_mock: HTTPXMock):
         _ = resolver.resolve_public_key("unknown")
 
 
+def test_url_bad_key_resolver_pattern():
+    with pytest.raises(ValueError):
+        _ = UrlKeyResolver(client_database_base_url="ftp://nodeman/api/v1/node/{key_id}/public_key")
+
+    with pytest.raises(ValueError):
+        _ = UrlKeyResolver(client_database_base_url="ftp://keys")
+
+
 def test_url_key_resolver_contextlib(httpx_mock: HTTPXMock):
     key_id = "xyzzy"
     public_key = ed25519.Ed25519PrivateKey.generate().public_key()


### PR DESCRIPTION
Use `{key_id}` as pattern for key identifier in client database URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- None

- **Bug Fixes**
	- None

- **Documentation**
	- None

- **Refactor**
	- Updated key resolver URL pattern to use modern string formatting

- **Version Update**
	- Bumped project version from 1.2.0 to 1.2.1

- **Tests**
	- Updated test case to match new URL pattern formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->